### PR TITLE
Update Minecraft Wiki link to new domain

### DIFF
--- a/src/lib/datapack.js
+++ b/src/lib/datapack.js
@@ -3,7 +3,7 @@ import JSZip from 'jszip'
 import { saveAs } from 'file-saver'
 
 export const getPackFormat = (minecraftVersion) => {
-  // https://minecraft.fandom.com/wiki/Pack_format
+  // https://minecraft.wiki/w/Pack_format
   switch (minecraftVersion) {
     case '1.12': {
       return 3


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates the fandom wiki link accordingly.